### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ node_modules
 // .npmignore only
 src
 test
+.babelrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerebral-module-ui-driver",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A driver for connecting ui components to cerebral",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
`.babelrc` is being published in npm which causes `.babelrc` of the project root not to be honored. This is problematic if you want to add `transform-runtime` to support new ES6 features like `Object.assign` (without `transform-runtime` or global polyfill the code breaks in legacy browsers such as IE11). 
