### PR TITLE
add flag for turning off immediate form values updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerebral-module-ui-driver",
-  "version": "0.11.0",
+  "version": "0.10.1",
   "description": "A driver for connecting ui components to cerebral",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerebral-module-ui-driver",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A driver for connecting ui components to cerebral",
   "main": "lib/index.js",
   "scripts": {

--- a/src/actions/beginValidate.js
+++ b/src/actions/beginValidate.js
@@ -5,7 +5,8 @@ export default function beginValidate (context) {
       driverModuleName,
       fields,
       moduleName,
-      validateForm
+      validateForm,
+      shouldUpdateFormValue = true
     },
     state,
     output
@@ -43,8 +44,12 @@ export default function beginValidate (context) {
     if (value.isTypeValid) {
       value.isValid = true
       value.error = null
-      // update the form value
-      state.set([...formModule.path, field.name], value.typedValue)
+
+      if (shouldUpdateFormValue) {
+        // update the form value
+        state.set([...formModule.path, field.name], value.typedValue)
+      }
+
       // validate the value
       const formField = form.fields[field.name] || {}
       if (typeof formField.validate === 'function') {

--- a/src/bindings/input.js
+++ b/src/bindings/input.js
@@ -15,7 +15,7 @@ export default function ({
   props,
   propsMap
 }) {
-  return function bindInput (fieldName, fieldProps = {}, noFormatting) {
+  return function bindInput (fieldName, fieldProps = {}, noFormatting, shouldUpdateFormValue) {
     const isFocusedPath = [...driverModule.path, ...formModule.path, 'fields', fieldName, 'isFocused']
     const formValue = getMeta(state, ['form', fieldName])
     const options = driverModule.meta.options
@@ -44,7 +44,8 @@ export default function ({
             name: fieldName,
             type: field.type,
             value: e.target.value
-          }]
+          }],
+          shouldUpdateFormValue
         })
       },
       [propsMap['isFocused']]: !!meta.isFocused,


### PR DESCRIPTION
I have a case where i need to update the "original" module's state value after the validation (if the user input doesn't pass the validation i don't want it to be reflected in the actual module). Currently ui-driver is setting the casted value in `beginValidate` action before running all the validation functions. This PR adds a flag that would allow me to turn off updating the original module state in `beginValidate` action, so that I can set it within the `onAfterValidate` callback after my validations are done.
